### PR TITLE
Remove version for the GoRelease:v1.26.2

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,3 @@
-version: 2
-
 before:
   hooks:
     - go mod tidy


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
Remove version for the GoRelease:v1.26.2